### PR TITLE
Return the same model for an identifier

### DIFF
--- a/src/Provider/LabsExperimentProvider.php
+++ b/src/Provider/LabsExperimentProvider.php
@@ -7,33 +7,38 @@ use Faker\Provider\Base;
 
 final class LabsExperimentProvider extends Base
 {
+    private $experiments = [];
+
     public function labsExperimentSnippetV1(int $number = null) : array
     {
-        Assert::thatNullOr($number)->min(1, 'Number must be at least 1');
+        $data = $this->labsExperimentV1($number);
 
-        $data = [
-            'number' => $number ?? $this->generator->numberBetween(1),
-            'title' => $this->generator->sentence,
-            'published' => $this->generator->dateTimeBetween('2012-01-01')->format('Y-m-d\TH:i:s\Z'),
-            'image' => [
-                'banner' => $this->generator->bannerV1,
-                'thumbnail' => $this->generator->thumbnailV1,
-            ],
-        ];
-
-        if ($this->generator->boolean()) {
-            $data['impactStatement'] = $this->generator->text;
-        }
+        unset($data['content']);
 
         return $data;
     }
 
     public function labsExperimentV1(int $number = null) : array
     {
-        $data = $this->generator->labsExperimentSnippetV1($number);
+        if (!isset($this->experiments[$number])) {
+            Assert::thatNullOr($number)->min(1, 'Number must be at least 1');
 
-        $data['content'] = $this->generator->blocksV1(5);
+            $this->experiments[$number] = [
+                'number' => $number ?? $this->generator->numberBetween(1),
+                'title' => $this->generator->sentence,
+                'published' => $this->generator->dateTimeBetween('2012-01-01')->format('Y-m-d\TH:i:s\Z'),
+                'image' => [
+                    'banner' => $this->generator->bannerV1,
+                    'thumbnail' => $this->generator->thumbnailV1,
+                ],
+                'content' => $this->generator->blocksV1(5),
+            ];
 
-        return $data;
+            if ($this->generator->boolean()) {
+                $this->experiments[$number]['impactStatement'] = $this->generator->text;
+            }
+        }
+
+        return $this->experiments[$number];
     }
 }

--- a/test/Provider/LabsExperimentProviderTest.php
+++ b/test/Provider/LabsExperimentProviderTest.php
@@ -30,4 +30,19 @@ final class LabsExperimentProviderTest extends ProviderTestCase
     {
         $this->validate($this->getFaker()->labsExperimentV1, '/elife/api/model/labs-experiment.v1.json');
     }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_labs_experiment_v1_once()
+    {
+        $first = $this->getFaker()->labsExperimentV1(1);
+        $second = $this->getFaker()->labsExperimentV1(1);
+        $snippet = $this->getFaker()->labsExperimentSnippetV1(1);
+        $different = $this->getFaker()->labsExperimentV1(2);
+
+        $this->assertSame($first['title'], $second['title']);
+        $this->assertSame($first['title'], $snippet['title']);
+        $this->assertNotSame($first['title'], $different['title']);
+    }
 }


### PR DESCRIPTION
If requesting a particular object multiple times, we usually want the same one. Not sure if this should be the user's job or not. Thoughts @giorgiosironi?